### PR TITLE
Add SwiftUI achievement tracker app and shared core module

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+.build/
+.DS_Store
+xcuserdata/
+DerivedData/

--- a/Package.swift
+++ b/Package.swift
@@ -1,0 +1,25 @@
+// swift-tools-version: 6.0
+import PackageDescription
+
+let package = Package(
+    name: "AchievementLife",
+    platforms: [
+        .iOS(.v17),
+        .macOS(.v13)
+    ],
+    products: [
+        .library(
+            name: "AchievementCore",
+            targets: ["AchievementCore"]
+        )
+    ],
+    targets: [
+        .target(
+            name: "AchievementCore"
+        ),
+        .testTarget(
+            name: "AchievementCoreTests",
+            dependencies: ["AchievementCore"]
+        )
+    ]
+)

--- a/README.md
+++ b/README.md
@@ -1,0 +1,64 @@
+# Achievement Life
+
+Achievement Life is a SwiftUI iPhone app concept that gamifies everyday habits. Track progress, collect statistics, and keep momentum through customizable achievements, local reminders, and iconography that fits your goals.
+
+## Highlights
+
+- **Daily dashboard** that shows all achievements due for the selected day, with quick completion toggles and progress indicators.
+- **Flexible scheduling** that supports daily, weekly, monthly, custom-interval, or specific-date achievements.
+- **Custom achievements** created through an editor that lets you configure points, categories, schedules, reminders, and iconography.
+- **Statistics and insights** including streak tracking, completion rates, and upcoming schedule previews.
+- **Local notifications** via `UNUserNotificationCenter`, with a scheduler that can be swapped out when integrating with push notification providers.
+- **Template gallery** that ships with ready-made achievements for chores, studying, and fitness routines.
+- **Icon picker** powered by SF Symbols, with the ability to extend toward stock photo APIs for richer imagery.
+- **Extensibility hooks** to layer in Game Center leaderboards, cosmetics, or other reward systems based on earned points.
+
+## Project Layout
+
+```
+AchievementLife/
+├── Package.swift                  # Swift Package describing the shared logic module
+├── README.md                      # Project overview
+├── Sources/
+│   └── AchievementCore/           # Platform-neutral models, persistence, and statistics helpers
+├── Tests/
+│   └── AchievementCoreTests/      # Unit tests that validate scheduling, persistence, and statistics
+└── iOSApp/
+    └── AchievementLife/           # SwiftUI application files ready for Xcode
+```
+
+The `AchievementCore` package contains all core models and state management. It can be imported by other platforms or reused in future targets (watchOS, macOS, or server sync services). The SwiftUI application under `iOSApp/` consumes the package and provides all user interface components.
+
+## Getting Started
+
+1. Open `iOSApp/AchievementLife/AchievementLifeApp.swift` in Xcode (15 or later recommended).
+2. Create an Xcode project that references the `AchievementCore` Swift package located at the repository root.
+3. Build and run on an iPhone simulator running iOS 17 or later.
+
+### Notifications
+
+The view model requests local notification permissions on launch. To test reminders:
+
+1. Allow notification permission when prompted in the simulator or on device.
+2. Add reminder times while creating or editing an achievement.
+3. Use the Settings tab to reschedule reminders.
+
+### Extending the Experience
+
+- **Leaderboards / Skins:** Use the `AchievementStatistics` totals to sync with Game Center leaderboards or unlock cosmetic rewards after reaching certain point thresholds.
+- **Cloud sync:** Swap `AchievementPersistence` with a cloud-backed store (CloudKit, Firebase) to keep progress in sync across devices.
+- **Stock photo icons:** Replace `IconPickerView` with a picker backed by an API such as Unsplash or Pexels, and store the resulting URL in `IconReference.remoteURL`.
+
+## Running Tests
+
+The shared logic is validated with Swift Package Manager tests:
+
+```bash
+swift test
+```
+
+These tests cover schedule recurrence logic, statistics calculation, and persistence.
+
+## License
+
+This project is available under the MIT License. See [LICENSE](LICENSE) for details.

--- a/Sources/AchievementCore/Models/Achievement.swift
+++ b/Sources/AchievementCore/Models/Achievement.swift
@@ -1,0 +1,52 @@
+import Foundation
+
+public struct Achievement: Codable, Identifiable, Equatable, Sendable {
+    public var id: UUID
+    public var title: String
+    public var detail: String
+    public var icon: IconReference
+    public var points: Int
+    public var category: String
+    public var schedule: AchievementSchedule
+    public var reminderTimes: [DateComponents]
+    public var createdAt: Date
+    public var isArchived: Bool
+
+    public init(
+        id: UUID = UUID(),
+        title: String,
+        detail: String,
+        icon: IconReference,
+        points: Int = 10,
+        category: String = "General",
+        schedule: AchievementSchedule,
+        reminderTimes: [DateComponents] = [],
+        createdAt: Date = Date(),
+        isArchived: Bool = false
+    ) {
+        self.id = id
+        self.title = title
+        self.detail = detail
+        self.icon = icon
+        self.points = points
+        self.category = category
+        self.schedule = schedule
+        self.reminderTimes = reminderTimes
+        self.createdAt = createdAt
+        self.isArchived = isArchived
+    }
+}
+
+public struct AchievementCompletion: Codable, Identifiable, Equatable, Sendable {
+    public var id: UUID
+    public var achievementID: Achievement.ID
+    public var completedAt: Date
+    public var pointsEarned: Int
+
+    public init(id: UUID = UUID(), achievementID: Achievement.ID, completedAt: Date, pointsEarned: Int) {
+        self.id = id
+        self.achievementID = achievementID
+        self.completedAt = completedAt
+        self.pointsEarned = pointsEarned
+    }
+}

--- a/Sources/AchievementCore/Models/AchievementSchedule.swift
+++ b/Sources/AchievementCore/Models/AchievementSchedule.swift
@@ -1,0 +1,164 @@
+import Foundation
+
+public enum AchievementSchedule: Codable, Equatable, Sendable {
+    case daily
+    case weekly(Set<Weekday>)
+    case monthly(Set<Int>)
+    case specificDates([DateComponents])
+    case customInterval(days: Int, anchorDate: Date)
+
+    enum CodingKeys: String, CodingKey {
+        case type
+        case weekdays
+        case monthDays
+        case dates
+        case interval
+        case anchor
+    }
+
+    private enum ScheduleType: String, Codable {
+        case daily
+        case weekly
+        case monthly
+        case specificDates
+        case customInterval
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        let type = try container.decode(ScheduleType.self, forKey: .type)
+        switch type {
+        case .daily:
+            self = .daily
+        case .weekly:
+            let weekdays = try container.decode(Set<Weekday>.self, forKey: .weekdays)
+            self = .weekly(weekdays)
+        case .monthly:
+            let days = try container.decode(Set<Int>.self, forKey: .monthDays)
+            self = .monthly(days)
+        case .specificDates:
+            let dates = try container.decode([DateComponents].self, forKey: .dates)
+            self = .specificDates(dates)
+        case .customInterval:
+            let days = try container.decode(Int.self, forKey: .interval)
+            let anchor = try container.decode(Date.self, forKey: .anchor)
+            self = .customInterval(days: days, anchorDate: anchor)
+        }
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        switch self {
+        case .daily:
+            try container.encode(ScheduleType.daily, forKey: .type)
+        case .weekly(let weekdays):
+            try container.encode(ScheduleType.weekly, forKey: .type)
+            try container.encode(weekdays, forKey: .weekdays)
+        case .monthly(let days):
+            try container.encode(ScheduleType.monthly, forKey: .type)
+            try container.encode(days, forKey: .monthDays)
+        case .specificDates(let dates):
+            try container.encode(ScheduleType.specificDates, forKey: .type)
+            try container.encode(dates, forKey: .dates)
+        case .customInterval(let days, let anchor):
+            try container.encode(ScheduleType.customInterval, forKey: .type)
+            try container.encode(days, forKey: .interval)
+            try container.encode(anchor, forKey: .anchor)
+        }
+    }
+
+    public func isDue(on date: Date, calendar: Calendar) -> Bool {
+        switch self {
+        case .daily:
+            return true
+        case .weekly(let weekdays):
+            let weekday = Weekday(rawValue: calendar.component(.weekday, from: date)) ?? .monday
+            return weekdays.contains(weekday)
+        case .monthly(let days):
+            let day = calendar.component(.day, from: date)
+            return days.contains(day)
+        case .specificDates(let components):
+            let comps = calendar.dateComponents([.year, .month, .day], from: date)
+            return components.contains(where: { matches($0, comps, calendar: calendar) })
+        case .customInterval(let interval, let anchorDate):
+            let start = calendar.startOfDay(for: anchorDate)
+            let target = calendar.startOfDay(for: date)
+            guard target >= start else { return false }
+            let diff = calendar.dateComponents([.day], from: start, to: target).day ?? 0
+            return diff % interval == 0
+        }
+    }
+
+    public func nextOccurrences(from startDate: Date, limit: Int, calendar: Calendar) -> [Date] {
+        guard limit > 0 else { return [] }
+        switch self {
+        case .daily:
+            return stride(from: 0, to: limit, by: 1).compactMap { offset in
+                calendar.date(byAdding: .day, value: offset, to: calendar.startOfDay(for: startDate))
+            }
+        case .weekly(let weekdays):
+            return nextWeeklyOccurrences(weekdays: weekdays, startDate: startDate, limit: limit, calendar: calendar)
+        case .monthly(let days):
+            return nextMonthlyOccurrences(days: days, startDate: startDate, limit: limit, calendar: calendar)
+        case .specificDates(let dates):
+            let sorted = dates.compactMap { calendar.date(from: $0) }.sorted()
+            return sorted.filter { $0 >= calendar.startOfDay(for: startDate) }.prefix(limit).map { $0 }
+        case .customInterval(let days, let anchorDate):
+            let anchor = calendar.startOfDay(for: anchorDate)
+            var results: [Date] = []
+            var current = anchor
+            while results.count < limit {
+                if current >= calendar.startOfDay(for: startDate) {
+                    results.append(current)
+                }
+                guard let next = calendar.date(byAdding: .day, value: days, to: current) else { break }
+                current = next
+            }
+            return results
+        }
+    }
+
+    private func matches(_ lhs: DateComponents, _ rhs: DateComponents, calendar: Calendar) -> Bool {
+        let yearMatch = lhs.year == nil || lhs.year == rhs.year
+        let monthMatch = lhs.month == nil || lhs.month == rhs.month
+        let dayMatch = lhs.day == nil || lhs.day == rhs.day
+        return yearMatch && monthMatch && dayMatch
+    }
+
+    private func nextWeeklyOccurrences(weekdays: Set<Weekday>, startDate: Date, limit: Int, calendar: Calendar) -> [Date] {
+        guard !weekdays.isEmpty else { return [] }
+        var results: [Date] = []
+        var current = calendar.startOfDay(for: startDate)
+        while results.count < limit {
+            let weekday = Weekday(rawValue: calendar.component(.weekday, from: current)) ?? .monday
+            if weekdays.contains(weekday) {
+                results.append(current)
+            }
+            guard let next = calendar.date(byAdding: .day, value: 1, to: current) else { break }
+            current = next
+        }
+        return results
+    }
+
+    private func nextMonthlyOccurrences(days: Set<Int>, startDate: Date, limit: Int, calendar: Calendar) -> [Date] {
+        let validDays = days.filter { $0 >= 1 && $0 <= 31 }.sorted()
+        guard !validDays.isEmpty else { return [] }
+        var results: [Date] = []
+        var monthCursor = calendar.startOfDay(for: startDate)
+        let startOfDay = calendar.startOfDay(for: startDate)
+        while results.count < limit {
+            for day in validDays {
+                var components = calendar.dateComponents([.year, .month], from: monthCursor)
+                components.day = day
+                guard let date = calendar.date(from: components) else { continue }
+                if date >= startOfDay {
+                    results.append(date)
+                    if results.count == limit { break }
+                }
+            }
+            guard let nextMonth = calendar.date(byAdding: DateComponents(month: 1), to: monthCursor) else { break }
+            monthCursor = nextMonth
+        }
+        return results
+    }
+}

--- a/Sources/AchievementCore/Models/AchievementStatistics.swift
+++ b/Sources/AchievementCore/Models/AchievementStatistics.swift
@@ -1,0 +1,35 @@
+import Foundation
+
+public struct AchievementStatistics: Codable, Equatable, Sendable {
+    public var totalAchievements: Int
+    public var completedAchievements: Int
+    public var completionRate: Double
+    public var totalPointsEarned: Int
+    public var currentStreak: Int
+    public var bestStreak: Int
+    public var completionsByWeekday: [Weekday: Int]
+    public var completionHistory: [Date: Int]
+    public var categoryBreakdown: [String: Int]
+
+    public init(
+        totalAchievements: Int,
+        completedAchievements: Int,
+        completionRate: Double,
+        totalPointsEarned: Int,
+        currentStreak: Int,
+        bestStreak: Int,
+        completionsByWeekday: [Weekday: Int],
+        completionHistory: [Date: Int],
+        categoryBreakdown: [String: Int]
+    ) {
+        self.totalAchievements = totalAchievements
+        self.completedAchievements = completedAchievements
+        self.completionRate = completionRate
+        self.totalPointsEarned = totalPointsEarned
+        self.currentStreak = currentStreak
+        self.bestStreak = bestStreak
+        self.completionsByWeekday = completionsByWeekday
+        self.completionHistory = completionHistory
+        self.categoryBreakdown = categoryBreakdown
+    }
+}

--- a/Sources/AchievementCore/Models/AchievementTemplate.swift
+++ b/Sources/AchievementCore/Models/AchievementTemplate.swift
@@ -1,0 +1,76 @@
+import Foundation
+
+public struct AchievementTemplate: Codable, Equatable, Sendable, Identifiable {
+    public var id: UUID
+    public var title: String
+    public var detail: String
+    public var icon: IconReference
+    public var points: Int
+    public var category: String
+    public var schedule: AchievementSchedule
+
+    public init(
+        id: UUID = UUID(),
+        title: String,
+        detail: String,
+        icon: IconReference,
+        points: Int,
+        category: String,
+        schedule: AchievementSchedule
+    ) {
+        self.id = id
+        self.title = title
+        self.detail = detail
+        self.icon = icon
+        self.points = points
+        self.category = category
+        self.schedule = schedule
+    }
+}
+
+public extension Array where Element == AchievementTemplate {
+    static var everydayWellness: [AchievementTemplate] {
+        [
+            AchievementTemplate(
+                title: "Make Your Bed",
+                detail: "Start the day with a quick win by making your bed.",
+                icon: .system("bed.double.fill"),
+                points: 5,
+                category: "Morning",
+                schedule: .daily
+            ),
+            AchievementTemplate(
+                title: "Tidy the Kitchen",
+                detail: "Do the dishes or wipe down the counters after meals.",
+                icon: .system("fork.knife"),
+                points: 10,
+                category: "Home",
+                schedule: .daily
+            ),
+            AchievementTemplate(
+                title: "Workout Session",
+                detail: "Complete a workout or head to the gym.",
+                icon: .system("dumbbell.fill"),
+                points: 20,
+                category: "Fitness",
+                schedule: .weekly([.monday, .wednesday, .friday])
+            ),
+            AchievementTemplate(
+                title: "Study Block",
+                detail: "Focus on studying or learning for at least 45 minutes.",
+                icon: .system("book.fill"),
+                points: 15,
+                category: "Learning",
+                schedule: .weekly([.monday, .tuesday, .wednesday, .thursday])
+            ),
+            AchievementTemplate(
+                title: "Laundry Day",
+                detail: "Stay on top of laundry so it never piles up.",
+                icon: .system("laundry"),
+                points: 15,
+                category: "Home",
+                schedule: .weekly([.saturday])
+            )
+        ]
+    }
+}

--- a/Sources/AchievementCore/Models/IconReference.swift
+++ b/Sources/AchievementCore/Models/IconReference.swift
@@ -1,0 +1,29 @@
+import Foundation
+
+public enum IconSource: String, Codable, Sendable {
+    case systemSymbol
+    case remoteURL
+}
+
+public struct IconReference: Codable, Equatable, Sendable {
+    public var source: IconSource
+    public var value: String
+
+    public init(source: IconSource, value: String) {
+        self.source = source
+        self.value = value
+    }
+
+    public static func system(_ name: String) -> IconReference {
+        IconReference(source: .systemSymbol, value: name)
+    }
+
+    public static func remote(_ url: URL) -> IconReference {
+        IconReference(source: .remoteURL, value: url.absoluteString)
+    }
+
+    public var remoteURL: URL? {
+        guard source == .remoteURL else { return nil }
+        return URL(string: value)
+    }
+}

--- a/Sources/AchievementCore/Models/Weekday.swift
+++ b/Sources/AchievementCore/Models/Weekday.swift
@@ -1,0 +1,22 @@
+import Foundation
+
+public enum Weekday: Int, CaseIterable, Codable, Sendable {
+    case sunday = 1
+    case monday
+    case tuesday
+    case wednesday
+    case thursday
+    case friday
+    case saturday
+
+    public var localizedName: String {
+        let symbols = Calendar.current.weekdaySymbols
+        return symbols[(rawValue - 1) % symbols.count]
+    }
+
+    public func advanced(by offset: Int) -> Weekday {
+        let all = Weekday.allCases
+        let index = (rawValue - 1 + offset) % all.count
+        return all[(index + all.count) % all.count]
+    }
+}

--- a/Sources/AchievementCore/Persistence/AchievementPersistence.swift
+++ b/Sources/AchievementCore/Persistence/AchievementPersistence.swift
@@ -1,0 +1,41 @@
+import Foundation
+
+public struct AchievementPersistence: Sendable {
+    public let fileURL: URL
+
+    public init(directoryURL: URL? = nil, fileName: String = "achievement_state.json") {
+        if let directoryURL {
+            self.fileURL = directoryURL.appendingPathComponent(fileName)
+        } else {
+            #if os(iOS) || os(macOS)
+            let defaultDirectory = FileManager.default.urls(for: .documentDirectory, in: .userDomainMask).first
+            #else
+            let defaultDirectory = FileManager.default.temporaryDirectory
+            #endif
+            self.fileURL = defaultDirectory
+                .appendingPathComponent(fileName)
+        }
+    }
+
+    public func load() throws -> AchievementState {
+        guard FileManager.default.fileExists(atPath: fileURL.path) else {
+            return AchievementState()
+        }
+        let data = try Data(contentsOf: fileURL)
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+        return try decoder.decode(AchievementState.self, from: data)
+    }
+
+    public func save(_ state: AchievementState) throws {
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+        encoder.dateEncodingStrategy = .iso8601
+        let data = try encoder.encode(state)
+        let directory = fileURL.deletingLastPathComponent()
+        if !FileManager.default.fileExists(atPath: directory.path) {
+            try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        }
+        try data.write(to: fileURL, options: [.atomic])
+    }
+}

--- a/Sources/AchievementCore/State/AchievementState.swift
+++ b/Sources/AchievementCore/State/AchievementState.swift
@@ -1,0 +1,145 @@
+import Foundation
+
+public struct AchievementState: Codable, Sendable {
+    public private(set) var achievements: [Achievement]
+    public private(set) var completions: [AchievementCompletion]
+
+    public init(achievements: [Achievement] = [], completions: [AchievementCompletion] = []) {
+        self.achievements = achievements
+        self.completions = completions.sorted(by: { $0.completedAt < $1.completedAt })
+    }
+
+    public mutating func addAchievement(_ achievement: Achievement) {
+        achievements.append(achievement)
+    }
+
+    public mutating func updateAchievement(_ achievement: Achievement) {
+        guard let index = achievements.firstIndex(where: { $0.id == achievement.id }) else { return }
+        achievements[index] = achievement
+    }
+
+    public mutating func removeAchievement(id: Achievement.ID) {
+        achievements.removeAll { $0.id == id }
+        completions.removeAll { $0.achievementID == id }
+    }
+
+    public mutating func toggleCompletion(
+        for achievementID: Achievement.ID,
+        on date: Date = Date(),
+        calendar: Calendar = .current
+    ) {
+        if let existing = completion(on: date, for: achievementID, calendar: calendar) {
+            completions.removeAll { $0.id == existing.id }
+        } else {
+            logCompletion(for: achievementID, on: date, calendar: calendar)
+        }
+    }
+
+    @discardableResult
+    public mutating func logCompletion(
+        for achievementID: Achievement.ID,
+        on date: Date = Date(),
+        calendar: Calendar = .current
+    ) -> AchievementCompletion? {
+        guard achievements.contains(where: { $0.id == achievementID }) else { return nil }
+        let normalized = calendar.startOfDay(for: date)
+        let points = achievements.first(where: { $0.id == achievementID })?.points ?? 0
+        let completion = AchievementCompletion(achievementID: achievementID, completedAt: normalized, pointsEarned: points)
+        completions.append(completion)
+        completions.sort(by: { $0.completedAt < $1.completedAt })
+        return completion
+    }
+
+    public func completion(on date: Date, for achievementID: Achievement.ID, calendar: Calendar = .current) -> AchievementCompletion? {
+        let target = calendar.startOfDay(for: date)
+        return completions.first(where: { $0.achievementID == achievementID && calendar.isDate($0.completedAt, inSameDayAs: target) })
+    }
+
+    public func isCompleted(_ achievementID: Achievement.ID, on date: Date = Date(), calendar: Calendar = .current) -> Bool {
+        completion(on: date, for: achievementID, calendar: calendar) != nil
+    }
+
+    public func achievementsDue(on date: Date, calendar: Calendar = .current) -> [Achievement] {
+        achievements.filter { !$0.isArchived && $0.schedule.isDue(on: date, calendar: calendar) }
+    }
+
+    public func statistics(for range: DateInterval, calendar: Calendar = .current) -> AchievementStatistics {
+        let relevantCompletions = completions.filter { range.contains($0.completedAt) }
+        let totalAchievements = achievements.filter { !$0.isArchived }.count
+        let completedToday = relevantCompletions.count
+        let completionRate: Double
+        if totalAchievements == 0 {
+            completionRate = 0
+        } else {
+            let days = max(1, calendar.dateComponents([.day], from: range.start, to: range.end).day ?? 1)
+            completionRate = Double(completedToday) / Double(totalAchievements * days)
+        }
+        let totalPoints = relevantCompletions.reduce(0) { $0 + $1.pointsEarned }
+        let history = buildHistory(range: range, completions: relevantCompletions, calendar: calendar)
+        let streaks = calculateStreaks(range: range, completions: relevantCompletions, calendar: calendar)
+        let weekdayBreakdown = Dictionary(grouping: relevantCompletions) { completion -> Weekday in
+            let weekdayValue = calendar.component(.weekday, from: completion.completedAt)
+            return Weekday(rawValue: weekdayValue) ?? .monday
+        }.mapValues { $0.count }
+        let categoryBreakdown = Dictionary(grouping: relevantCompletions) { completion -> String in
+            achievements.first(where: { $0.id == completion.achievementID })?.category ?? "General"
+        }.mapValues { $0.count }
+
+        return AchievementStatistics(
+            totalAchievements: totalAchievements,
+            completedAchievements: completedToday,
+            completionRate: completionRate,
+            totalPointsEarned: totalPoints,
+            currentStreak: streaks.current,
+            bestStreak: streaks.best,
+            completionsByWeekday: weekdayBreakdown,
+            completionHistory: history,
+            categoryBreakdown: categoryBreakdown
+        )
+    }
+
+    public func upcomingOccurrences(for achievementID: Achievement.ID, from startDate: Date, limit: Int = 5, calendar: Calendar = .current) -> [Date] {
+        guard let achievement = achievements.first(where: { $0.id == achievementID }) else { return [] }
+        return achievement.schedule.nextOccurrences(from: startDate, limit: limit, calendar: calendar)
+    }
+
+    private func buildHistory(range: DateInterval, completions: [AchievementCompletion], calendar: Calendar) -> [Date: Int] {
+        var history: [Date: Int] = [:]
+        var currentDate = calendar.startOfDay(for: range.start)
+        while currentDate <= range.end {
+            history[currentDate] = 0
+            guard let next = calendar.date(byAdding: .day, value: 1, to: currentDate) else { break }
+            currentDate = next
+        }
+        for completion in completions {
+            let day = calendar.startOfDay(for: completion.completedAt)
+            history[day, default: 0] += 1
+        }
+        return history
+    }
+
+    private func calculateStreaks(range: DateInterval, completions: [AchievementCompletion], calendar: Calendar) -> (current: Int, best: Int) {
+        let days = completions.map { calendar.startOfDay(for: $0.completedAt) }.sorted()
+        guard !days.isEmpty else { return (0, 0) }
+        var best = 0
+        var current = 0
+        var previousDay: Date?
+        for day in days {
+            if let previous = previousDay, let diff = calendar.dateComponents([.day], from: previous, to: day).day, diff == 1 {
+                current += 1
+            } else if previousDay == nil {
+                current = 1
+            } else {
+                current = 1
+            }
+            best = max(best, current)
+            previousDay = day
+        }
+
+        let today = calendar.startOfDay(for: Date())
+        if let last = days.last, let diff = calendar.dateComponents([.day], from: last, to: today).day, diff > 1 {
+            current = 0
+        }
+        return (current, best)
+    }
+}

--- a/Tests/AchievementCoreTests/AchievementPersistenceTests.swift
+++ b/Tests/AchievementCoreTests/AchievementPersistenceTests.swift
@@ -1,0 +1,25 @@
+import XCTest
+@testable import AchievementCore
+
+final class AchievementPersistenceTests: XCTestCase {
+    func testSaveAndLoadState() throws {
+        var state = AchievementState()
+        let achievement = Achievement(
+            title: "Read a Book",
+            detail: "Read for 20 minutes",
+            icon: .system("book.fill"),
+            points: 10,
+            category: "Learning",
+            schedule: .daily
+        )
+        state.addAchievement(achievement)
+        state.logCompletion(for: achievement.id, on: Date(), calendar: .current)
+        let tempURL = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        let persistence = AchievementPersistence(directoryURL: tempURL)
+        try persistence.save(state)
+
+        let loaded = try persistence.load()
+        XCTAssertEqual(loaded.achievements.count, 1)
+        XCTAssertEqual(loaded.completions.count, 1)
+    }
+}

--- a/Tests/AchievementCoreTests/AchievementScheduleTests.swift
+++ b/Tests/AchievementCoreTests/AchievementScheduleTests.swift
@@ -1,0 +1,64 @@
+import XCTest
+@testable import AchievementCore
+
+final class AchievementScheduleTests: XCTestCase {
+    private let calendar = Calendar(identifier: .gregorian)
+
+    func testDailyScheduleIsAlwaysDue() {
+        let schedule = AchievementSchedule.daily
+        let today = Date()
+        XCTAssertTrue(schedule.isDue(on: today, calendar: calendar))
+    }
+
+    func testWeeklyScheduleMatchesSelectedDays() {
+        let schedule = AchievementSchedule.weekly([.monday, .wednesday])
+        let monday = makeDate(year: 2024, month: 3, day: 4)
+        let tuesday = makeDate(year: 2024, month: 3, day: 5)
+        XCTAssertTrue(schedule.isDue(on: monday, calendar: calendar))
+        XCTAssertFalse(schedule.isDue(on: tuesday, calendar: calendar))
+    }
+
+    func testMonthlyScheduleMatchesDays() {
+        let schedule = AchievementSchedule.monthly([1, 15])
+        let first = makeDate(year: 2024, month: 4, day: 1)
+        let second = makeDate(year: 2024, month: 4, day: 10)
+        XCTAssertTrue(schedule.isDue(on: first, calendar: calendar))
+        XCTAssertFalse(schedule.isDue(on: second, calendar: calendar))
+    }
+
+    func testSpecificDatesSchedule() {
+        let components = [DateComponents(year: 2024, month: 12, day: 25)]
+        let schedule = AchievementSchedule.specificDates(components)
+        let match = makeDate(year: 2024, month: 12, day: 25)
+        let miss = makeDate(year: 2024, month: 12, day: 26)
+        XCTAssertTrue(schedule.isDue(on: match, calendar: calendar))
+        XCTAssertFalse(schedule.isDue(on: miss, calendar: calendar))
+    }
+
+    func testCustomIntervalSchedule() {
+        let anchor = makeDate(year: 2024, month: 1, day: 1)
+        let schedule = AchievementSchedule.customInterval(days: 3, anchorDate: anchor)
+        let due = makeDate(year: 2024, month: 1, day: 7)
+        let notDue = makeDate(year: 2024, month: 1, day: 8)
+        XCTAssertTrue(schedule.isDue(on: due, calendar: calendar))
+        XCTAssertFalse(schedule.isDue(on: notDue, calendar: calendar))
+    }
+
+    func testNextOccurrencesForWeeklySchedule() {
+        let schedule = AchievementSchedule.weekly([.monday, .friday])
+        let start = makeDate(year: 2024, month: 3, day: 5) // Tuesday
+        let occurrences = schedule.nextOccurrences(from: start, limit: 3, calendar: calendar)
+        XCTAssertEqual(occurrences.count, 3)
+        XCTAssertEqual(calendar.component(.weekday, from: occurrences[0]), Weekday.friday.rawValue)
+        XCTAssertEqual(calendar.component(.weekday, from: occurrences[1]), Weekday.monday.rawValue)
+    }
+
+    private func makeDate(year: Int, month: Int, day: Int) -> Date {
+        var components = DateComponents()
+        components.year = year
+        components.month = month
+        components.day = day
+        components.calendar = calendar
+        return calendar.date(from: components) ?? Date()
+    }
+}

--- a/Tests/AchievementCoreTests/AchievementStateTests.swift
+++ b/Tests/AchievementCoreTests/AchievementStateTests.swift
@@ -1,0 +1,59 @@
+import XCTest
+@testable import AchievementCore
+
+final class AchievementStateTests: XCTestCase {
+    private let calendar = Calendar(identifier: .gregorian)
+
+    func testToggleCompletionAddsAndRemoves() {
+        let achievement = makeSampleAchievement()
+        var state = AchievementState(achievements: [achievement])
+        let today = calendar.startOfDay(for: Date())
+        XCTAssertFalse(state.isCompleted(achievement.id, on: today, calendar: calendar))
+        state.toggleCompletion(for: achievement.id, on: today, calendar: calendar)
+        XCTAssertTrue(state.isCompleted(achievement.id, on: today, calendar: calendar))
+        state.toggleCompletion(for: achievement.id, on: today, calendar: calendar)
+        XCTAssertFalse(state.isCompleted(achievement.id, on: today, calendar: calendar))
+    }
+
+    func testStatistics() {
+        let achievement = makeSampleAchievement()
+        var state = AchievementState(achievements: [achievement])
+        let start = makeDate(year: 2024, month: 4, day: 1)
+        let end = makeDate(year: 2024, month: 4, day: 7)
+        let interval = DateInterval(start: start, end: end)
+        state.logCompletion(for: achievement.id, on: start, calendar: calendar)
+        state.logCompletion(for: achievement.id, on: makeDate(year: 2024, month: 4, day: 3), calendar: calendar)
+        let stats = state.statistics(for: interval, calendar: calendar)
+        XCTAssertEqual(stats.totalAchievements, 1)
+        XCTAssertEqual(stats.completedAchievements, 2)
+        XCTAssertGreaterThan(stats.totalPointsEarned, 0)
+        XCTAssertEqual(stats.completionHistory.count, 7)
+    }
+
+    func testUpcomingOccurrences() {
+        let achievement = makeSampleAchievement()
+        let state = AchievementState(achievements: [achievement])
+        let occurrences = state.upcomingOccurrences(for: achievement.id, from: Date(), calendar: calendar)
+        XCTAssertFalse(occurrences.isEmpty)
+    }
+
+    private func makeSampleAchievement() -> Achievement {
+        Achievement(
+            title: "Gym Session",
+            detail: "Complete a strength workout",
+            icon: .system("dumbbell.fill"),
+            points: 20,
+            category: "Fitness",
+            schedule: .weekly([.monday, .wednesday, .friday])
+        )
+    }
+
+    private func makeDate(year: Int, month: Int, day: Int) -> Date {
+        var components = DateComponents()
+        components.calendar = calendar
+        components.year = year
+        components.month = month
+        components.day = day
+        return calendar.date(from: components) ?? Date()
+    }
+}

--- a/iOSApp/AchievementLife/AchievementLifeApp.swift
+++ b/iOSApp/AchievementLife/AchievementLifeApp.swift
@@ -1,0 +1,17 @@
+import SwiftUI
+import AchievementCore
+
+@main
+struct AchievementLifeApp: App {
+    @StateObject private var viewModel = AchievementViewModel()
+
+    var body: some Scene {
+        WindowGroup {
+            ContentView()
+                .environmentObject(viewModel)
+                .task {
+                    await viewModel.requestNotificationPermissions()
+                }
+        }
+    }
+}

--- a/iOSApp/AchievementLife/ContentView.swift
+++ b/iOSApp/AchievementLife/ContentView.swift
@@ -1,0 +1,34 @@
+import SwiftUI
+import AchievementCore
+
+struct ContentView: View {
+    @EnvironmentObject private var viewModel: AchievementViewModel
+
+    var body: some View {
+        TabView {
+            DashboardView()
+                .tabItem {
+                    Label("Dashboard", systemImage: "checkmark.circle")
+                }
+
+            StatsOverviewView()
+                .tabItem {
+                    Label("Stats", systemImage: "chart.bar.xaxis")
+                }
+
+            SettingsView()
+                .tabItem {
+                    Label("Settings", systemImage: "gear")
+                }
+        }
+        .environment(
+            \._achievementFormatter,
+            AchievementFormatter(calendar: viewModel.calendar)
+        )
+    }
+}
+
+#Preview {
+    ContentView()
+        .environmentObject(AchievementViewModel(preview: true))
+}

--- a/iOSApp/AchievementLife/Helpers/AchievementFormatter.swift
+++ b/iOSApp/AchievementLife/Helpers/AchievementFormatter.swift
@@ -1,0 +1,36 @@
+import Foundation
+import SwiftUI
+
+struct AchievementFormatter {
+    let calendar: Calendar
+
+    func format(date: Date, style: DateFormatter.Style = .medium) -> String {
+        let formatter = DateFormatter()
+        formatter.calendar = calendar
+        formatter.dateStyle = style
+        formatter.timeStyle = .none
+        return formatter.string(from: date)
+    }
+
+    func formatTime(from components: DateComponents) -> String {
+        let formatter = DateFormatter()
+        formatter.calendar = calendar
+        formatter.timeStyle = .short
+        formatter.dateStyle = .none
+        if let date = calendar.date(from: components) {
+            return formatter.string(from: date)
+        }
+        return "Time"
+    }
+}
+
+private struct AchievementFormatterKey: EnvironmentKey {
+    static let defaultValue = AchievementFormatter(calendar: Calendar(identifier: .gregorian))
+}
+
+extension EnvironmentValues {
+    var achievementFormatter: AchievementFormatter {
+        get { self[AchievementFormatterKey.self] }
+        set { self[AchievementFormatterKey.self] = newValue }
+    }
+}

--- a/iOSApp/AchievementLife/Helpers/NotificationScheduler.swift
+++ b/iOSApp/AchievementLife/Helpers/NotificationScheduler.swift
@@ -1,0 +1,51 @@
+import Foundation
+import UserNotifications
+import AchievementCore
+
+struct NotificationScheduler {
+    func requestAuthorization() async -> Bool {
+        let center = UNUserNotificationCenter.current()
+        let settings = await center.notificationSettings()
+        if settings.authorizationStatus == .notDetermined {
+            do {
+                let granted = try await center.requestAuthorization(options: [.alert, .badge, .sound])
+                return granted
+            } catch {
+                return false
+            }
+        }
+        return settings.authorizationStatus == .authorized || settings.authorizationStatus == .provisional
+    }
+
+    func scheduleNotifications(for achievement: Achievement, calendar: Calendar) {
+        guard !achievement.reminderTimes.isEmpty else { return }
+        let center = UNUserNotificationCenter.current()
+        for components in achievement.reminderTimes {
+            let content = UNMutableNotificationContent()
+            content.title = achievement.title
+            content.body = achievement.detail
+            content.sound = .default
+
+            var triggerComponents = components
+            triggerComponents.calendar = calendar
+            if triggerComponents.timeZone == nil {
+                triggerComponents.timeZone = calendar.timeZone
+            }
+
+            let identifier = notificationIdentifier(for: achievement.id, components: components)
+            let trigger = UNCalendarNotificationTrigger(dateMatching: triggerComponents, repeats: true)
+            let request = UNNotificationRequest(identifier: identifier, content: content, trigger: trigger)
+            center.add(request)
+        }
+    }
+
+    func clearScheduledNotifications() {
+        UNUserNotificationCenter.current().removeAllPendingNotificationRequests()
+    }
+
+    private func notificationIdentifier(for id: UUID, components: DateComponents) -> String {
+        let hour = components.hour ?? 0
+        let minute = components.minute ?? 0
+        return "achievement_\(id.uuidString)_\(hour)_\(minute)"
+    }
+}

--- a/iOSApp/AchievementLife/ViewModels/AchievementViewModel.swift
+++ b/iOSApp/AchievementLife/ViewModels/AchievementViewModel.swift
@@ -1,0 +1,152 @@
+import Foundation
+import SwiftUI
+import UserNotifications
+import AchievementCore
+
+@MainActor
+final class AchievementViewModel: ObservableObject {
+    @Published private(set) var state: AchievementState
+    @Published var selectedDate: Date
+    @Published var notificationsEnabled: Bool
+
+    private let persistence: AchievementPersistence
+    private let notificationScheduler = NotificationScheduler()
+    private(set) var templates: [AchievementTemplate] = .everydayWellness
+
+    let calendar: Calendar
+
+    init(
+        state: AchievementState = AchievementState(),
+        persistence: AchievementPersistence? = nil,
+        calendar: Calendar = .current,
+        preview: Bool = false
+    ) {
+        self.calendar = calendar
+        self.persistence = persistence ?? AchievementPersistence()
+        if preview {
+            self.state = AchievementState(achievements: Self.previewAchievements, completions: [])
+        } else if let loaded = try? self.persistence.load() {
+            self.state = loaded
+        } else {
+            self.state = state
+        }
+        self.selectedDate = calendar.startOfDay(for: Date())
+        self.notificationsEnabled = false
+    }
+
+    var achievementsDueToday: [Achievement] {
+        state.achievementsDue(on: selectedDate, calendar: calendar)
+    }
+
+    var todaysCompletionCount: Int {
+        state.completions.filter { calendar.isDate($0.completedAt, inSameDayAs: selectedDate) }.count
+    }
+
+    var completionStats: AchievementStatistics {
+        let start = calendar.startOfDay(for: selectedDate)
+        let historicalStart = calendar.date(byAdding: .day, value: -30, to: start) ?? start
+        let end = calendar.date(byAdding: .day, value: 1, to: start) ?? start
+        let interval = DateInterval(start: historicalStart, end: end)
+        return state.statistics(for: interval, calendar: calendar)
+    }
+
+    func isCompleted(_ achievement: Achievement) -> Bool {
+        state.isCompleted(achievement.id, on: selectedDate, calendar: calendar)
+    }
+
+    func toggleCompletion(_ achievement: Achievement) {
+        state.toggleCompletion(for: achievement.id, on: selectedDate, calendar: calendar)
+        persistState()
+    }
+
+    func addAchievement(_ achievement: Achievement) {
+        state.addAchievement(achievement)
+        persistState()
+        scheduleNotifications(for: achievement)
+    }
+
+    func updateAchievement(_ achievement: Achievement) {
+        state.updateAchievement(achievement)
+        persistState()
+        scheduleNotifications(for: achievement)
+    }
+
+    func removeAchievements(at offsets: IndexSet) {
+        offsets.map { state.achievements[$0] }.forEach { achievement in
+            state.removeAchievement(id: achievement.id)
+        }
+        persistState()
+    }
+
+    func nextOccurrences(for achievement: Achievement, limit: Int = 5) -> [Date] {
+        state.upcomingOccurrences(for: achievement.id, from: selectedDate, limit: limit, calendar: calendar)
+    }
+
+    func saveFromTemplate(_ template: AchievementTemplate) {
+        let achievement = Achievement(
+            title: template.title,
+            detail: template.detail,
+            icon: template.icon,
+            points: template.points,
+            category: template.category,
+            schedule: template.schedule
+        )
+        addAchievement(achievement)
+    }
+
+    func reloadState() {
+        if let loaded = try? persistence.load() {
+            state = loaded
+        }
+    }
+
+    func requestNotificationPermissions() async {
+        notificationsEnabled = await notificationScheduler.requestAuthorization()
+        if notificationsEnabled {
+            for achievement in state.achievements {
+                scheduleNotifications(for: achievement)
+            }
+        }
+    }
+
+    func scheduleNotifications(for achievement: Achievement) {
+        guard notificationsEnabled else { return }
+        notificationScheduler.scheduleNotifications(for: achievement, calendar: calendar)
+    }
+
+    func refreshReminders() {
+        notificationScheduler.clearScheduledNotifications()
+        if notificationsEnabled {
+            for achievement in state.achievements {
+                scheduleNotifications(for: achievement)
+            }
+        }
+    }
+
+    private func persistState() {
+        try? persistence.save(state)
+    }
+}
+
+private extension AchievementViewModel {
+    static var previewAchievements: [Achievement] {
+        [
+            Achievement(
+                title: "Make the Bed",
+                detail: "Smooth the sheets and fluff the pillows.",
+                icon: .system("bed.double.fill"),
+                points: 5,
+                category: "Home",
+                schedule: .daily
+            ),
+            Achievement(
+                title: "Gym Session",
+                detail: "Complete a 45-minute workout.",
+                icon: .system("dumbbell.fill"),
+                points: 20,
+                category: "Fitness",
+                schedule: .weekly([.monday, .wednesday, .friday])
+            )
+        ]
+    }
+}

--- a/iOSApp/AchievementLife/Views/Dashboard/AchievementEditorView.swift
+++ b/iOSApp/AchievementLife/Views/Dashboard/AchievementEditorView.swift
@@ -1,0 +1,142 @@
+import SwiftUI
+import AchievementCore
+
+struct AchievementEditorView: View {
+    @Environment(\.dismiss) private var dismiss
+    @State private var title: String = ""
+    @State private var detail: String = ""
+    @State private var points: Int = 10
+    @State private var category: String = "General"
+    @State private var schedule: AchievementSchedule = .daily
+    @State private var icon: IconReference = .system("sparkles")
+    @State private var reminderTimes: [DateComponents] = []
+    @State private var showingIconPicker = false
+    @State private var showingScheduleEditor = false
+
+    var onSave: (Achievement) -> Void
+
+    var body: some View {
+        Form {
+            Section("Basics") {
+                TextField("Title", text: $title)
+                TextField("Description", text: $detail, axis: .vertical)
+                Stepper(value: $points, in: 5...100, step: 5) {
+                    HStack {
+                        Label("Points", systemImage: "star.fill")
+                        Spacer()
+                        Text("\(points)")
+                            .monospacedDigit()
+                    }
+                }
+                TextField("Category", text: $category)
+            }
+
+            Section("Schedule") {
+                Button {
+                    showingScheduleEditor = true
+                } label: {
+                    HStack {
+                        Label("Frequency", systemImage: "calendar")
+                        Spacer()
+                        Text(scheduleDescription)
+                            .foregroundStyle(.secondary)
+                    }
+                }
+            }
+
+            Section("Icon & Reminders") {
+                Button {
+                    showingIconPicker = true
+                } label: {
+                    HStack {
+                        Label("Icon", systemImage: "paintpalette")
+                        Spacer()
+                        AchievementIconView(icon: icon, isCompleted: false)
+                    }
+                }
+
+                ForEach(reminderTimes.indices, id: \.self) { index in
+                    DatePicker(
+                        "Reminder #\(index + 1)",
+                        selection: Binding(
+                            get: { reminderDate(from: reminderTimes[index]) },
+                            set: { reminderTimes[index] = calendarComponents(from: $0) }
+                        ),
+                        displayedComponents: [.hourAndMinute]
+                    )
+                }
+                .onDelete { offsets in
+                    reminderTimes.remove(atOffsets: offsets)
+                }
+
+                Button {
+                    reminderTimes.append(calendarComponents(from: Date()))
+                } label: {
+                    Label("Add Reminder", systemImage: "bell.badge")
+                }
+            }
+        }
+        .navigationTitle("New Achievement")
+        .toolbar {
+            ToolbarItem(placement: .topBarLeading) {
+                Button("Cancel") { dismiss() }
+            }
+            ToolbarItem(placement: .topBarTrailing) {
+                Button("Save") {
+                    let achievement = Achievement(
+                        title: title,
+                        detail: detail,
+                        icon: icon,
+                        points: points,
+                        category: category,
+                        schedule: schedule,
+                        reminderTimes: reminderTimes
+                    )
+                    onSave(achievement)
+                    dismiss()
+                }
+                .disabled(title.isEmpty)
+            }
+        }
+        .sheet(isPresented: $showingIconPicker) {
+            IconPickerView(selectedIcon: $icon)
+        }
+        .sheet(isPresented: $showingScheduleEditor) {
+            NavigationStack {
+                ScheduleEditorView(schedule: $schedule)
+            }
+        }
+    }
+
+    private var scheduleDescription: String {
+        switch schedule {
+        case .daily:
+            return "Daily"
+        case .weekly(let days):
+            let names = days.sorted { $0.rawValue < $1.rawValue }.map { $0.localizedName }
+            return names.joined(separator: ", ")
+        case .monthly(let days):
+            let sorted = days.sorted()
+            return sorted.map { "Day \($0)" }.joined(separator: ", ")
+        case .specificDates(let dates):
+            let formatter = DateFormatter()
+            formatter.calendar = Calendar.current
+            formatter.dateStyle = .medium
+            let calendar = Calendar.current
+            return dates.compactMap { calendar.date(from: $0) }.map { formatter.string(from: $0) }.joined(separator: ", ")
+        case .customInterval(let days, _):
+            return "Every \(days) days"
+        }
+    }
+
+    private func reminderDate(from components: DateComponents) -> Date {
+        let calendar = Calendar.current
+        return calendar.date(from: components) ?? Date()
+    }
+
+    private func calendarComponents(from date: Date) -> DateComponents {
+        var components = Calendar.current.dateComponents([.hour, .minute], from: date)
+        components.calendar = Calendar.current
+        return components
+    }
+}

--- a/iOSApp/AchievementLife/Views/Dashboard/AchievementRowView.swift
+++ b/iOSApp/AchievementLife/Views/Dashboard/AchievementRowView.swift
@@ -1,0 +1,115 @@
+import SwiftUI
+import AchievementCore
+
+struct AchievementRowView: View {
+    let achievement: Achievement
+    let isCompleted: Bool
+    var onToggle: () -> Void
+
+    var body: some View {
+        HStack(spacing: 16) {
+            AchievementIconView(icon: achievement.icon, isCompleted: isCompleted)
+            VStack(alignment: .leading, spacing: 4) {
+                Text(achievement.title)
+                    .font(.headline)
+                Text(achievement.detail)
+                    .font(.subheadline)
+                    .foregroundStyle(.secondary)
+                HStack {
+                    Label("\(achievement.points) pts", systemImage: "star.fill")
+                        .labelStyle(.iconOnly)
+                        .foregroundStyle(.yellow)
+                    Text("\(achievement.points) pts")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                    Spacer()
+                    Text(achievement.category)
+                        .font(.caption)
+                        .padding(.horizontal, 8)
+                        .padding(.vertical, 4)
+                        .background(Color.accentColor.opacity(0.12))
+                        .clipShape(Capsule())
+                }
+            }
+            Spacer()
+            Button(action: onToggle) {
+                Image(systemName: isCompleted ? "checkmark.seal.fill" : "circle")
+                    .font(.title2)
+                    .foregroundStyle(isCompleted ? Color.green : Color.secondary)
+                    .symbolEffect(.bounce, value: isCompleted)
+            }
+            .buttonStyle(.plain)
+        }
+        .padding(.vertical, 8)
+    }
+}
+
+struct AchievementIconView: View {
+    let icon: IconReference
+    let isCompleted: Bool
+
+    var body: some View {
+        ZStack {
+            Circle()
+                .fill(isCompleted ? Color.green.opacity(0.2) : Color.accentColor.opacity(0.12))
+                .frame(width: 48, height: 48)
+            switch icon.source {
+            case .systemSymbol:
+                Image(systemName: icon.value)
+                    .font(.title2)
+                    .foregroundStyle(isCompleted ? Color.green : Color.accentColor)
+            case .remoteURL:
+                RemoteAchievementIcon(url: icon.remoteURL)
+            }
+        }
+    }
+}
+
+private struct RemoteAchievementIcon: View {
+    let url: URL?
+
+    var body: some View {
+        if let url {
+            AsyncImage(url: url) { phase in
+                switch phase {
+                case .empty:
+                    ProgressView()
+                case .success(let image):
+                    image
+                        .resizable()
+                        .scaledToFit()
+                case .failure:
+                    fallbackIcon
+                @unknown default:
+                    fallbackIcon
+                }
+            }
+            .frame(width: 32, height: 32)
+        } else {
+            fallbackIcon
+        }
+    }
+
+    private var fallbackIcon: some View {
+        Image(systemName: "app.fill")
+            .font(.title2)
+            .foregroundStyle(.secondary)
+    }
+}
+
+#Preview {
+    AchievementRowView(
+        achievement: Achievement(
+            title: "Daily Stretch",
+            detail: "Spend 10 minutes stretching",
+            icon: .system("figure.cooldown"),
+            points: 10,
+            category: "Wellness",
+            schedule: .daily
+        ),
+        isCompleted: true,
+        onToggle: {}
+    )
+    .padding()
+    .previewLayout(.sizeThatFits)
+}

--- a/iOSApp/AchievementLife/Views/Dashboard/DashboardView.swift
+++ b/iOSApp/AchievementLife/Views/Dashboard/DashboardView.swift
@@ -1,0 +1,176 @@
+import SwiftUI
+import AchievementCore
+
+struct DashboardView: View {
+    @EnvironmentObject private var viewModel: AchievementViewModel
+    @State private var showingAddSheet = false
+    @State private var showingTemplates = false
+
+    var body: some View {
+        NavigationStack {
+            VStack(spacing: 16) {
+                header
+                progressSummary
+                if viewModel.achievementsDueToday.isEmpty {
+                    EmptyDashboardState(showingAddSheet: $showingAddSheet, showingTemplates: $showingTemplates)
+                } else {
+                    List {
+                        Section("Today's Achievements") {
+                            ForEach(viewModel.achievementsDueToday) { achievement in
+                                AchievementRowView(
+                                    achievement: achievement,
+                                    isCompleted: viewModel.isCompleted(achievement)
+                                ) {
+                                    viewModel.toggleCompletion(achievement)
+                                }
+                                .contentShape(Rectangle())
+                                .contextMenu {
+                                    Button("View Details") {
+                                        showingDetail(for: achievement)
+                                    }
+                                    Button("Skip Today", role: .destructive) {
+                                        viewModel.toggleCompletion(achievement)
+                                    }
+                                }
+                            }
+                            .onDelete(perform: viewModel.removeAchievements)
+                        }
+                    }
+                    .listStyle(.insetGrouped)
+                }
+            }
+            .padding([.horizontal, .bottom])
+            .navigationTitle("Achievement Life")
+            .toolbar {
+                ToolbarItemGroup(placement: .topBarTrailing) {
+                    Button {
+                        showingTemplates = true
+                    } label: {
+                        Label("Templates", systemImage: "sparkles")
+                    }
+                    Button {
+                        showingAddSheet = true
+                    } label: {
+                        Label("Add Achievement", systemImage: "plus")
+                    }
+                    .accessibilityIdentifier("addAchievementButton")
+                }
+            }
+            .sheet(isPresented: $showingAddSheet) {
+                NavigationStack {
+                    AchievementEditorView { newAchievement in
+                        viewModel.addAchievement(newAchievement)
+                    }
+                }
+            }
+            .sheet(isPresented: $showingTemplates) {
+                TemplateGalleryView(templates: viewModel.templates) { template in
+                    viewModel.saveFromTemplate(template)
+                }
+            }
+        }
+    }
+
+    private var header: some View {
+        HStack {
+            VStack(alignment: .leading) {
+                Text("Today")
+                    .font(.title2).bold()
+                Text(Date.now, style: .date)
+                    .foregroundStyle(.secondary)
+            }
+            Spacer()
+            Menu {
+                DatePicker("Jump to Date", selection: $viewModel.selectedDate, displayedComponents: .date)
+                    .datePickerStyle(.graphical)
+            } label: {
+                Label("Select Date", systemImage: "calendar")
+            }
+        }
+    }
+
+    private var progressSummary: some View {
+        let stats = viewModel.completionStats
+        let totalToday = max(1, viewModel.achievementsDueToday.count)
+        let completed = viewModel.todaysCompletionCount
+
+        return VStack(alignment: .leading, spacing: 12) {
+            ProgressView(value: Double(completed), total: Double(totalToday)) {
+                Text("Daily Progress")
+                    .font(.headline)
+            } currentValueLabel: {
+                Text("\(completed)/\(totalToday)")
+                    .monospacedDigit()
+            }
+            .tint(.green)
+
+            HStack {
+                StatPill(title: "Streak", value: "\(stats.currentStreak) 🔥")
+                StatPill(title: "Best", value: "\(stats.bestStreak)")
+                StatPill(title: "Points", value: "\(stats.totalPointsEarned)")
+            }
+        }
+        .padding()
+        .background(.thinMaterial)
+        .clipShape(RoundedRectangle(cornerRadius: 16))
+    }
+
+    private func showingDetail(for achievement: Achievement) {
+        // Placeholder for navigation hooks if detail view is added later
+    }
+}
+
+private struct StatPill: View {
+    let title: String
+    let value: String
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 4) {
+            Text(title.uppercased())
+                .font(.caption)
+                .foregroundStyle(.secondary)
+            Text(value)
+                .font(.headline)
+        }
+        .padding(.vertical, 8)
+        .padding(.horizontal, 12)
+        .background(Color.accentColor.opacity(0.1))
+        .clipShape(RoundedRectangle(cornerRadius: 12))
+    }
+}
+
+private struct EmptyDashboardState: View {
+    @Binding var showingAddSheet: Bool
+    @Binding var showingTemplates: Bool
+
+    var body: some View {
+        VStack(spacing: 12) {
+            Image(systemName: "wand.and.stars")
+                .font(.largeTitle)
+                .padding(12)
+            Text("No achievements yet")
+                .font(.headline)
+            Text("Create custom achievements or explore curated templates to start earning points.")
+                .font(.subheadline)
+                .multilineTextAlignment(.center)
+                .foregroundStyle(.secondary)
+                .padding(.horizontal)
+            HStack {
+                Button("Browse Templates") {
+                    showingTemplates = true
+                }
+                Button("Create Achievement") {
+                    showingAddSheet = true
+                }
+                .buttonStyle(.borderedProminent)
+            }
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .padding()
+        .background(
+            RoundedRectangle(cornerRadius: 20)
+                .stroke(style: .init(lineWidth: 1, dash: [4]))
+                .foregroundStyle(.secondary)
+        )
+    }
+}

--- a/iOSApp/AchievementLife/Views/Dashboard/IconPickerView.swift
+++ b/iOSApp/AchievementLife/Views/Dashboard/IconPickerView.swift
@@ -1,0 +1,85 @@
+import SwiftUI
+import AchievementCore
+
+struct IconPickerView: View {
+    @Environment(\.dismiss) private var dismiss
+    @Binding var selectedIcon: IconReference
+    @State private var searchText: String = ""
+
+    private let symbolCategories: [IconCategory] = IconCategory.defaultCategories
+
+    var body: some View {
+        NavigationStack {
+            List {
+                if !searchText.isEmpty {
+                    Section("Search Results") {
+                        symbolGrid(for: filteredSymbols)
+                    }
+                }
+
+                ForEach(symbolCategories) { category in
+                    Section(category.name) {
+                        symbolGrid(for: category.symbols)
+                    }
+                }
+            }
+            .searchable(text: $searchText)
+            .navigationTitle("Choose Icon")
+            .toolbar {
+                ToolbarItem(placement: .topBarTrailing) {
+                    Button("Done") { dismiss() }
+                }
+            }
+        }
+    }
+
+    private var filteredSymbols: [String] {
+        let query = searchText.lowercased()
+        guard !query.isEmpty else { return [] }
+        return IconCategory.allSymbols.filter { $0.contains(query) }
+    }
+
+    @ViewBuilder
+    private func symbolGrid(for symbols: [String]) -> some View {
+        LazyVGrid(columns: Array(repeating: GridItem(.adaptive(minimum: 44), spacing: 12), count: 3), spacing: 12) {
+            ForEach(symbols, id: \.self) { symbol in
+                Button {
+                    selectedIcon = .system(symbol)
+                    dismiss()
+                } label: {
+                    VStack {
+                        Image(systemName: symbol)
+                            .font(.title2)
+                            .frame(width: 44, height: 44)
+                            .background(selectedIcon.value == symbol ? Color.accentColor.opacity(0.2) : Color.clear)
+                            .clipShape(RoundedRectangle(cornerRadius: 12))
+                        Text(symbol)
+                            .font(.caption2)
+                            .lineLimit(1)
+                    }
+                }
+                .buttonStyle(.plain)
+            }
+        }
+        .padding(.vertical, 8)
+    }
+}
+
+private struct IconCategory: Identifiable {
+    let id = UUID()
+    let name: String
+    let symbols: [String]
+
+    static let defaultCategories: [IconCategory] = [
+        IconCategory(name: "Habits", symbols: ["checkmark.circle", "sparkles", "target", "flag.checkered"]),
+        IconCategory(name: "Home", symbols: ["bed.double.fill", "fork.knife", "house.fill", "sofa.fill", "laundry"]),
+        IconCategory(name: "Health", symbols: ["heart.fill", "cross.case.fill", "bandage.fill", "pill" ]),
+        IconCategory(name: "Fitness", symbols: ["figure.run", "dumbbell.fill", "bicycle", "sportscourt"]),
+        IconCategory(name: "Learning", symbols: ["book.fill", "graduationcap.fill", "brain.head.profile", "pencil"]),
+        IconCategory(name: "Lifestyle", symbols: ["music.note", "gamecontroller.fill", "paintbrush.pointed", "leaf.fill"])
+    ]
+
+    static var allSymbols: [String] {
+        defaultCategories.flatMap(\.symbols)
+    }
+}

--- a/iOSApp/AchievementLife/Views/Dashboard/ScheduleEditorView.swift
+++ b/iOSApp/AchievementLife/Views/Dashboard/ScheduleEditorView.swift
@@ -1,0 +1,215 @@
+import SwiftUI
+import AchievementCore
+
+struct ScheduleEditorView: View {
+    @Environment(\.dismiss) private var dismiss
+    @Binding var schedule: AchievementSchedule
+    @State private var selectedFrequency: Frequency = .daily
+    @State private var selectedWeekdays: Set<Weekday> = []
+    @State private var monthlyDays: Set<Int> = []
+    @State private var specificDates: [Date] = []
+    @State private var intervalDays: Int = 2
+    @State private var anchorDate: Date = Date()
+
+    enum Frequency: String, CaseIterable, Identifiable {
+        case daily
+        case weekly
+        case monthly
+        case specificDates
+        case customInterval
+
+        var id: String { rawValue }
+
+        var title: String {
+            switch self {
+            case .daily: return "Daily"
+            case .weekly: return "Weekly"
+            case .monthly: return "Monthly"
+            case .specificDates: return "Specific Dates"
+            case .customInterval: return "Interval"
+            }
+        }
+    }
+
+    init(schedule: Binding<AchievementSchedule>) {
+        self._schedule = schedule
+        switch schedule.wrappedValue {
+        case .daily:
+            _selectedFrequency = State(initialValue: .daily)
+        case .weekly(let days):
+            _selectedFrequency = State(initialValue: .weekly)
+            _selectedWeekdays = State(initialValue: days)
+        case .monthly(let days):
+            _selectedFrequency = State(initialValue: .monthly)
+            _monthlyDays = State(initialValue: days)
+        case .specificDates(let dates):
+            _selectedFrequency = State(initialValue: .specificDates)
+            let calendar = Calendar.current
+            let resolved = dates.compactMap { calendar.date(from: $0) }
+            _specificDates = State(initialValue: resolved)
+        case .customInterval(let days, let anchor):
+            _selectedFrequency = State(initialValue: .customInterval)
+            _intervalDays = State(initialValue: days)
+            _anchorDate = State(initialValue: anchor)
+        }
+    }
+
+    var body: some View {
+        Form {
+            Picker("Frequency", selection: $selectedFrequency) {
+                ForEach(Frequency.allCases) { frequency in
+                    Text(frequency.title).tag(frequency)
+                }
+            }
+            .pickerStyle(.segmented)
+
+            switch selectedFrequency {
+            case .daily:
+                EmptyView()
+            case .weekly:
+                weekdaySelector
+            case .monthly:
+                monthlySelector
+            case .specificDates:
+                specificDateSelector
+            case .customInterval:
+                intervalSelector
+            }
+        }
+        .navigationTitle("Schedule")
+        .toolbar {
+            ToolbarItem(placement: .topBarLeading) {
+                Button("Cancel") { dismiss() }
+            }
+            ToolbarItem(placement: .topBarTrailing) {
+                Button("Done") {
+                    commitChanges()
+                    dismiss()
+                }
+            }
+        }
+        .onChange(of: selectedFrequency) { _ in
+            commitChanges()
+        }
+    }
+
+    private var weekdaySelector: some View {
+        VStack(alignment: .leading) {
+            Text("Select days")
+                .font(.headline)
+            LazyVGrid(columns: Array(repeating: GridItem(.flexible()), count: 3)) {
+                ForEach(Weekday.allCases, id: \.self) { weekday in
+                    Button {
+                        if selectedWeekdays.contains(weekday) {
+                            selectedWeekdays.remove(weekday)
+                        } else {
+                            selectedWeekdays.insert(weekday)
+                        }
+                        commitChanges()
+                    } label: {
+                        Text(weekday.localizedName.prefix(3))
+                            .font(.headline)
+                            .frame(maxWidth: .infinity)
+                            .padding(.vertical, 10)
+                            .background(selectedWeekdays.contains(weekday) ? Color.accentColor.opacity(0.2) : Color.gray.opacity(0.1))
+                            .clipShape(RoundedRectangle(cornerRadius: 8))
+                    }
+                    .buttonStyle(.plain)
+                }
+            }
+        }
+    }
+
+    private var monthlySelector: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            Text("Days in the month")
+                .font(.headline)
+            MonthDayGrid(days: Array(1...31), selections: $monthlyDays)
+                .onChange(of: monthlyDays) { _ in commitChanges() }
+        }
+    }
+
+    private var specificDateSelector: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            Text("Add calendar dates")
+                .font(.headline)
+            ForEach(specificDates.indices, id: \.self) { index in
+                HStack {
+                    DatePicker("Date #\(index + 1)", selection: Binding(
+                        get: { specificDates[index] },
+                        set: { specificDates[index] = $0 }
+                    ), displayedComponents: .date)
+                    Button {
+                        specificDates.remove(at: index)
+                        commitChanges()
+                    } label: {
+                        Image(systemName: "trash")
+                            .foregroundStyle(.red)
+                    }
+                    .buttonStyle(.plain)
+                }
+            }
+
+            Button {
+                specificDates.append(Date())
+                commitChanges()
+            } label: {
+                Label("Add Date", systemImage: "calendar.badge.plus")
+            }
+        }
+    }
+
+    private var intervalSelector: some View {
+        VStack(alignment: .leading, spacing: 16) {
+            Stepper(value: $intervalDays, in: 2...30) {
+                Text("Every \(intervalDays) days")
+            }
+            DatePicker("Anchor Date", selection: $anchorDate, displayedComponents: .date)
+        }
+        .onChange(of: intervalDays) { _ in commitChanges() }
+        .onChange(of: anchorDate) { _ in commitChanges() }
+    }
+
+    private func commitChanges() {
+        switch selectedFrequency {
+        case .daily:
+            schedule = .daily
+        case .weekly:
+            schedule = .weekly(selectedWeekdays)
+        case .monthly:
+            schedule = .monthly(monthlyDays)
+        case .specificDates:
+            let components = specificDates.map { Calendar.current.dateComponents([.year, .month, .day], from: $0) }
+            schedule = .specificDates(components)
+        case .customInterval:
+            schedule = .customInterval(days: intervalDays, anchorDate: anchorDate)
+        }
+    }
+}
+
+private struct MonthDayGrid: View {
+    let days: [Int]
+    @Binding var selections: Set<Int>
+
+    var body: some View {
+        LazyVGrid(columns: Array(repeating: GridItem(.flexible()), count: 5), spacing: 8) {
+            ForEach(days, id: \.self) { day in
+                let isSelected = selections.contains(day)
+                Button {
+                    if isSelected {
+                        selections.remove(day)
+                    } else {
+                        selections.insert(day)
+                    }
+                } label: {
+                    Text("\(day)")
+                        .frame(maxWidth: .infinity)
+                        .padding(.vertical, 8)
+                        .background(isSelected ? Color.accentColor.opacity(0.2) : Color.gray.opacity(0.1))
+                        .clipShape(RoundedRectangle(cornerRadius: 8))
+                }
+                .buttonStyle(.plain)
+            }
+        }
+    }
+}

--- a/iOSApp/AchievementLife/Views/Dashboard/TemplateGalleryView.swift
+++ b/iOSApp/AchievementLife/Views/Dashboard/TemplateGalleryView.swift
@@ -1,0 +1,43 @@
+import SwiftUI
+import AchievementCore
+
+struct TemplateGalleryView: View {
+    @Environment(\.dismiss) private var dismiss
+    let templates: [AchievementTemplate]
+    var onSelect: (AchievementTemplate) -> Void
+
+    var body: some View {
+        NavigationStack {
+            List {
+                ForEach(templates) { template in
+                    Button {
+                        onSelect(template)
+                        dismiss()
+                    } label: {
+                        HStack(spacing: 16) {
+                            AchievementIconView(icon: template.icon, isCompleted: false)
+                            VStack(alignment: .leading, spacing: 4) {
+                                Text(template.title)
+                                    .font(.headline)
+                                Text(template.detail)
+                                    .font(.subheadline)
+                                    .foregroundStyle(.secondary)
+                            }
+                            Spacer()
+                            Image(systemName: "chevron.right")
+                                .foregroundStyle(.secondary)
+                        }
+                        .padding(.vertical, 8)
+                    }
+                    .buttonStyle(.plain)
+                }
+            }
+            .navigationTitle("Templates")
+            .toolbar {
+                ToolbarItem(placement: .topBarTrailing) {
+                    Button("Done") { dismiss() }
+                }
+            }
+        }
+    }
+}

--- a/iOSApp/AchievementLife/Views/Settings/SettingsView.swift
+++ b/iOSApp/AchievementLife/Views/Settings/SettingsView.swift
@@ -1,0 +1,57 @@
+import SwiftUI
+import AchievementCore
+
+struct SettingsView: View {
+    @EnvironmentObject private var viewModel: AchievementViewModel
+
+    var body: some View {
+        NavigationStack {
+            Form {
+                Section("Notifications") {
+                    Toggle(isOn: $viewModel.notificationsEnabled) {
+                        Label("Enable reminders", systemImage: "bell")
+                    }
+                    .onChange(of: viewModel.notificationsEnabled) { newValue in
+                        if newValue {
+                            Task { await viewModel.requestNotificationPermissions() }
+                        } else {
+                            viewModel.refreshReminders()
+                        }
+                    }
+                    Button("Reschedule reminders") {
+                        viewModel.refreshReminders()
+                    }
+                }
+
+                Section("Data") {
+                    Button("Reload from storage") {
+                        viewModel.reloadState()
+                    }
+                    Button("Export achievements") {
+                        exportAchievements()
+                    }
+                }
+
+                Section("Roadmap") {
+                    Label("Leaderboards and skins support can plug into your earned points with Game Center or custom APIs.", systemImage: "gamecontroller")
+                        .font(.footnote)
+                        .foregroundStyle(.secondary)
+                        .fixedSize(horizontal: false, vertical: true)
+                }
+            }
+            .navigationTitle("Settings")
+        }
+    }
+
+    private func exportAchievements() {
+        guard let data = try? JSONEncoder().encode(viewModel.state) else { return }
+        let tempURL = FileManager.default.temporaryDirectory.appendingPathComponent("AchievementLifeExport.json")
+        try? data.write(to: tempURL)
+        // ShareSheet integration would go here in a full app implementation
+    }
+}
+
+#Preview {
+    SettingsView()
+        .environmentObject(AchievementViewModel(preview: true))
+}

--- a/iOSApp/AchievementLife/Views/Stats/StatsOverviewView.swift
+++ b/iOSApp/AchievementLife/Views/Stats/StatsOverviewView.swift
@@ -1,0 +1,117 @@
+import SwiftUI
+import AchievementCore
+
+struct StatsOverviewView: View {
+    @EnvironmentObject private var viewModel: AchievementViewModel
+    @Environment(\.achievementFormatter) private var formatter
+
+    var body: some View {
+        ScrollView {
+            VStack(alignment: .leading, spacing: 24) {
+                header
+                streakCard
+                pointsCard
+                weekdayBreakdown
+                upcomingList
+            }
+            .padding()
+        }
+        .navigationTitle("Stats")
+    }
+
+    private var header: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Text("Performance Snapshot")
+                .font(.largeTitle.bold())
+            Text("Track your momentum and see how consistent you have been.")
+                .foregroundStyle(.secondary)
+        }
+    }
+
+    private var streakCard: some View {
+        let stats = viewModel.completionStats
+        return VStack(alignment: .leading, spacing: 12) {
+            Label("Current Streak", systemImage: "flame.fill")
+                .font(.headline)
+                .foregroundStyle(.orange)
+            Text("\(stats.currentStreak) days")
+                .font(.system(size: 48, weight: .bold, design: .rounded))
+                .foregroundStyle(.orange)
+            Text("Best streak \(stats.bestStreak) days")
+                .foregroundStyle(.secondary)
+            ProgressView(value: Double(stats.currentStreak), total: Double(max(stats.bestStreak, 1)))
+                .tint(.orange)
+        }
+        .padding()
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(.orange.opacity(0.1))
+        .clipShape(RoundedRectangle(cornerRadius: 20))
+    }
+
+    private var pointsCard: some View {
+        let stats = viewModel.completionStats
+        return VStack(alignment: .leading, spacing: 12) {
+            Label("Achievement Points", systemImage: "star.fill")
+                .font(.headline)
+            Text("\(stats.totalPointsEarned) pts")
+                .font(.system(size: 40, weight: .semibold, design: .rounded))
+            Text("Completion rate \(Int(stats.completionRate * 100))%")
+                .foregroundStyle(.secondary)
+        }
+        .padding()
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(.yellow.opacity(0.15))
+        .clipShape(RoundedRectangle(cornerRadius: 20))
+    }
+
+    private var weekdayBreakdown: some View {
+        let stats = viewModel.completionStats
+        return VStack(alignment: .leading, spacing: 12) {
+            Label("Weekday Momentum", systemImage: "calendar")
+                .font(.headline)
+            ForEach(Weekday.allCases, id: \.self) { weekday in
+                let count = stats.completionsByWeekday[weekday, default: 0]
+                HStack {
+                    Text(weekday.localizedName)
+                    Spacer()
+                    Text("\(count)")
+                        .monospacedDigit()
+                }
+                .padding(.vertical, 8)
+                .padding(.horizontal)
+                .background(Color.gray.opacity(0.08))
+                .clipShape(RoundedRectangle(cornerRadius: 12))
+            }
+        }
+    }
+
+    private var upcomingList: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            Label("Upcoming Achievements", systemImage: "clock")
+                .font(.headline)
+            ForEach(viewModel.state.achievements) { achievement in
+                let occurrences = viewModel.nextOccurrences(for: achievement, limit: 3)
+                if !occurrences.isEmpty {
+                    VStack(alignment: .leading, spacing: 4) {
+                        Text(achievement.title)
+                            .font(.headline)
+                        ForEach(occurrences, id: \.self) { occurrence in
+                            Text(formatter.format(date: occurrence))
+                                .font(.caption)
+                                .foregroundStyle(.secondary)
+                        }
+                    }
+                    .padding()
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .background(.thinMaterial)
+                    .clipShape(RoundedRectangle(cornerRadius: 16))
+                }
+            }
+        }
+    }
+}
+
+#Preview {
+    StatsOverviewView()
+        .environmentObject(AchievementViewModel(preview: true))
+}


### PR DESCRIPTION
## Summary
- add the `AchievementCore` Swift package with models for achievements, recurrence rules, persistence, and statistics helpers
- implement an iOS SwiftUI app that surfaces a dashboard, statistics tab, templates, icon picker, and settings backed by the shared core logic
- document setup in a new README and cover the core logic with unit tests for scheduling, persistence, and state operations

## Testing
- `swift test`


------
https://chatgpt.com/codex/tasks/task_e_68ca5b123c6c83329461d3d2da18eb5d